### PR TITLE
TRITON-2304 New image server names

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "deps/javascriptlint"]
 	path = deps/javascriptlint
-	url = https://github.com/joyent/javascriptlint.git
+	url = https://github.com/TritonDataCenter/javascriptlint.git
 [submodule "deps/jsstyle"]
 	path = deps/jsstyle
-	url = https://github.com/joyent/jsstyle.git
+	url = https://github.com/TritonDataCenter/jsstyle.git
 [submodule "deps/restdown"]
 	path = deps/restdown
-	url = https://github.com/joyent/restdown.git
+	url = https://github.com/TritonDataCenter/restdown.git
 [submodule "deps/sdc-scripts"]
 	path = deps/sdc-scripts
-	url = https://github.com/joyent/sdc-scripts.git
+	url = https://github.com/TritonDataCenter/sdc-scripts.git
 [submodule "deps/restdown-brand-remora"]
 	path = deps/restdown-brand-remora
-	url = https://github.com/joyent/restdown-brand-remora.git
+	url = https://github.com/TritonDataCenter/restdown-brand-remora.git
 [submodule "deps/eng"]
-	url = https://github.com/joyent/eng
+	url = https://github.com/TritonDataCenter/eng
 	path = deps/eng

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # IMGAPI changelog
 
+## 4.12.0
+
+- TRITON-2304 New image server names
+
 ## 4.11.2
 
 - TRITON-2287 update sdc-imgapi base image to `triton-origin-x86_64-21.4.0`
@@ -14,7 +18,7 @@
 ## 4.11.0
 
 - TRITON-2228: Linux CN minimum viable product
-  
+
   Imgapi now supports importing LXC images for Linux compute nodes.
 
 ## 4.10.0
@@ -48,16 +52,16 @@
 
 ## 4.9.0
 
- - TRITON-2053 standalone imgapi could be easier to test with
+- TRITON-2053 standalone imgapi could be easier to test with
 
 ## 4.8.0
 
- - TRITON-2052 sdc-imgadm import should import from any channel by default
+- TRITON-2052 sdc-imgadm import should import from any channel by default
 
 ## 4.7.0
 
- - TRITON-1738 update imgapi base image to triton-origin-x86_64-18.4.0
- - TRITON-1737 imgapi should use node v6
+- TRITON-1738 update imgapi base image to triton-origin-x86_64-18.4.0
+- TRITON-1737 imgapi should use node v6
 
 ## 4.6.2
 
@@ -254,30 +258,30 @@ The REST API has *not* changed incompatibly.
   both DC-mode (i.e. a core instance in a Triton DC) and standalone
   IMGAPI deployments. Some of these affect DC-mode IMGAPI instances as
   well. Highlights:
-    - The origin image is changing from the venerable sdc-smartos@1.6.3
-      (fd2cc906-8938-11e3-beab-4359c665ac99) to the modern
-      sdc-minimal-multiarch-lts@15.4.1 (18b094b0-eb01-11e5-80c1-175dac7ddf02).
-      This follows plans from RFD 46 to move to origin images based on
-      this. When "triton-origin" images are produced, it is the intent
-      to switch imgapi to use those.
-    - The node version has moved from node 0.10 to 0.12.
-    - "bin/imgapi-standalone-*" scripts are provided for sane deployment,
-      and an Operator Guide was written.
-    - A standalone IMGAPI uses "boot/standalone/*" for booting,
-      "etc/standalone/*" for config, "smf/manifests/*-standalone.xml" for extra
-      services, and "tools/standalone" for extra scripts.
-    - The config file is now always at "/data/imgapi/etc/imgapi.config.json".
-      This is differs from most core Triton instances that render their
-      config file to somewhere under "/opt/smartdc/$name/...". Having
-      it under "/data/imgapi" means it is on the delegate dataset
-      for the instance, which is necessary for standalone deployments.
-      It doesn't hurt DC-mode deployments to have it there.
-    - Some config file changes: "manta" object at the top level (Manta
-      usage by IMGAPI isn't just about image storage), "databaseType"
-      instead of "database.type", "authType" instead of "auth.type",
-      etc. Generally, absolute paths have been removed from the *config*
-      and added to a "lib/constants.js" to simplify code and remove
-      clutter/featuritis from the config.
+  - The origin image is changing from the venerable sdc-smartos@1.6.3
+    (fd2cc906-8938-11e3-beab-4359c665ac99) to the modern
+    sdc-minimal-multiarch-lts@15.4.1 (18b094b0-eb01-11e5-80c1-175dac7ddf02).
+    This follows plans from RFD 46 to move to origin images based on
+    this. When "triton-origin" images are produced, it is the intent
+    to switch imgapi to use those.
+  - The node version has moved from node 0.10 to 0.12.
+  - "bin/imgapi-standalone-*" scripts are provided for sane deployment,
+    and an Operator Guide was written.
+  - A standalone IMGAPI uses "boot/standalone/*" for booting,
+    "etc/standalone/*" for config, "smf/manifests/*-standalone.xml" for extra
+    services, and "tools/standalone" for extra scripts.
+  - The config file is now always at "/data/imgapi/etc/imgapi.config.json".
+    This is differs from most core Triton instances that render their
+    config file to somewhere under "/opt/smartdc/$name/...". Having
+    it under "/data/imgapi" means it is on the delegate dataset
+    for the instance, which is necessary for standalone deployments.
+    It doesn't hurt DC-mode deployments to have it there.
+  - Some config file changes: "manta" object at the top level (Manta
+    usage by IMGAPI isn't just about image storage), "databaseType"
+    instead of "database.type", "authType" instead of "auth.type",
+    etc. Generally, absolute paths have been removed from the *config*
+    and added to a "lib/constants.js" to simplify code and remove
+    clutter/featuritis from the config.
 - "basic" auth support has been dropped. It hasn't been used for years
   and need not be supported.
 - Update stud dependency for OpenSSL update (IMGAPI-567). This was mainly
@@ -286,7 +290,6 @@ The REST API has *not* changed incompatibly.
   endpoint (IMGAPI-586). Initial client support for this endpoint was added
   in IMGAPI-579: `imgapi-cli reload-auth-keys`.
 - Dropped long obsolete, non-working, old migration scripts.
-
 
 ## 2.2.0
 

--- a/README.md
+++ b/README.md
@@ -6,28 +6,28 @@
 
 <!--
     Copyright 2019 Joyent, Inc.
+    Copyright 2022 MNX Cloud, Inc.
 -->
 
 # sdc-imgapi
 
-This repository is part of the Joyent Triton project. See the [contribution
-guidelines](https://github.com/joyent/triton/blob/master/CONTRIBUTING.md)
+This repository is part of the Triton Data Center project. See the [contribution
+guidelines](https://github.com/TritonDataCenter/triton/blob/master/CONTRIBUTING.md)
 and general documentation at the main
-[Triton project](https://github.com/joyent/triton) page.
+[Triton project](https://github.com/TritonDataCenter/triton) page.
 
 The Image API (IMGAPI) is the API in each Triton data center for managing
 instance images. It is also the software behind standalone IMGAPI services
-like <https://images.joyent.com> and <https://updates.joyent.com>.
+like <https://images.smartos.org> and <https://updates.tritondatacenter.com>.
 
+## Development
 
-# Development
-
-For an IMGAPI running as part of a Triton DataCenter, please start with a
-[CoaL setup](https://github.com/joyent/triton#getting-started). Then a common
+For an IMGAPI running as part of a Triton Data Center, please start with a
+[CoaL setup](https://github.com/TritonDataCenter/triton#getting-started). Then a common
 dev cycle goes something like this:
 
     # Make local changes:
-    git clone git@github.com:joyent/sdc-imgapi.git
+    git clone git@github.com:TritonDataCenter/sdc-imgapi.git
     cd sdc-imgapi
     make
 
@@ -42,8 +42,7 @@ laptop obviously cannot be sync'd to the SmartOS imgapi0 zone.
 For a standalone IMGAPI, see the [Operator Guide](./docs/operator-guide.md)
 for deployment and update details.
 
-
-# Testing
+## Testing
 
 A `mode=dc` IMGAPI's test suite is run as follows:
 
@@ -64,17 +63,15 @@ test suite. You can clean up via:
 
 For standalone IMGAPI instances the test suite is currently broken.
 
-
-# Related Repositories
+## Related Repositories
 
 There are a number of repositories that are relevant for IMGAPI and image
 management in SmartDataCenter and SmartOS.
 
-
 | Repo | Description |
 | ---- | ----------- |
-| https://github.com/joyent/sdc-imgapi.git | The IMGAPI server. This repository. |
-| https://github.com/joyent/node-sdc-clients.git | Includes imgapi.js node client library for using IMGAPI. |
-| https://github.com/joyent/node-imgmanifest.git | Defines the SDC/SmartOS Image manifest spec and support for validation and upgrade of image manifests. |
-| https://github.com/joyent/sdc-imgapi-cli.git | Includes the `*-imgadm` tools for common IMGAPI servers, e.g. `joyent-imgadm`, `sdc-imgadm`, `updates-imgadm` and a framework for tools for other IMGAPI servers. |
-| https://github.com/joyent/smartos-live.git | Holds the SmartOS `imgadm` tool (in src/img). This is the tool used on any SmartOS global zone to install image datasets into the zpool to enable provisioning VMs with that image. |
+| <https://github.com/TritonDataCenter/sdc-imgapi.git> | The IMGAPI server. This repository. |
+| <https://github.com/TritonDataCenter/node-sdc-clients.git> | Includes imgapi.js node client library for using IMGAPI. |
+| <https://github.com/TritonDataCenter/node-imgmanifest.git> | Defines the SDC/SmartOS Image manifest spec and support for validation and upgrade of image manifests. |
+| <https://github.com/TritonDataCenter/sdc-imgapi-cli.git> | Includes the `*-imgadm` tools for common IMGAPI servers, e.g. `images-imgadm`, `sdc-imgadm`, `updates-imgadm` and a framework for tools for other IMGAPI servers. |
+| <https://github.com/TritonDataCenter/smartos-live.git> | Holds the SmartOS `imgadm` tool (in src/img). This is the tool used on any SmartOS global zone to install image datasets into the zpool to enable provisioning VMs with that image. |

--- a/bin/imgapi-standalone-create
+++ b/bin/imgapi-standalone-create
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # Copyright 2017 Joyent, Inc.
+# Copyright 2022 MNX Cloud, Inc.
 #
 
 #
@@ -38,14 +39,14 @@ function usage () {
     echo ""
     echo "Where OWNER is an account UUID or login; IMAGE is an 'imgapi' image"
     echo "UUID or 'latest' to get the latest from the current (or given) "
-    echo "channel of updates.joyent.com; PACKAGE is a package UUID or name; and"
+    echo "channel of updates.tritondatacenter.com; PACKAGE is a package UUID or name; and"
     echo "ALIAS is an alias for the new instance (try to avoid '.' so the name"
     echo "will work as part of a DNS name)."
     echo ""
     echo "Examples:"
     echo ""
     echo "- First you'll need to get the create script to your headnode GZ:"
-    echo "    cd /var/tmp && curl -O https://raw.githubusercontent.com/joyent/sdc-imgapi/IMGAPI-567/bin/imgapi-standalone-create"
+    echo "    cd /var/tmp && curl -O https://raw.githubusercontent.com/TritonDataCenter/sdc-imgapi/IMGAPI-567/bin/imgapi-standalone-create"
     echo ""
     echo "- A play IMGAPI in COAL using a local 'trentm' COAL account and"
     echo "  /trent.mick/stor/tmp/images in Manta:"
@@ -142,7 +143,7 @@ fi
 imageJson=$(sdc-imgadm get $imageUuid 2>/dev/null || true)
 if [[ -z "$imageJson" ]]; then
     echo "Importing image $imageUuid from updates.jo"
-    sdc-imgadm import $imageUuid -S https://updates.joyent.com?channel=$channel
+    sdc-imgadm import $imageUuid -S https://updates.tritondatacenter.com?channel=$channel
     imageJson=$(sdc-imgadm get $imageUuid)
 else
     echo "Already have image $imageUuid in local IMGAPI"

--- a/bin/imgapi-standalone-gen-setup-config
+++ b/bin/imgapi-standalone-gen-setup-config
@@ -8,6 +8,7 @@
 
 /*
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
@@ -23,7 +24,7 @@
  * config vars are given as arguments to `imgapi-standalone-create`, e.g.
  *
  *      /opt/smartdc/imgapi/bin/imgapi-standalone-create \
- *          -m mode=public -m serverName="Joyent Public Images Repo" \
+ *          -m mode=public -m serverName="SmartOS Public Images Repo" \
  *          ...
  */
 
@@ -185,7 +186,7 @@ function main() {
         /*
          * "channels" may be the special value "standard", which is
          * transformed to .../etc/standalone/standard-channels.json. These are
-         * the channels used by updates.joyent.com.
+         * the channels used by updates.tritondatacenter.com.
          */
         function handleChannelsStandard(arg, next) {
             if (!arg.setupConfig.channels

--- a/bin/imgapi-standalone-reprovision
+++ b/bin/imgapi-standalone-reprovision
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # Copyright 2017 Joyent, Inc.
+# Copyright 2022 MNX Cloud, Inc.
 #
 
 #
@@ -38,11 +39,11 @@ function usage () {
     echo ""
     echo "Where INSTANCE is an existing standalone IMGAPI instance UUID,"
     echo "and IMAGE is an 'imgapi' image UUID or 'latest' to get the latest"
-    echo "from the current (or given) channel of updates.joyent.com."
+    echo "from the current (or given) channel of updates.tritondatacenter.com."
     echo ""
     echo "Examples:"
     echo ""
-    echo "- Reprovision an images.joyent.com inst with the latest experimental"
+    echo "- Reprovision an images.smartos.org inst with the latest experimental"
     echo "  'imgapi' image:"
     echo "      ./imgapi-standalone-reprovision -C experimental \\"
     echo "          205c49c8-715e-11e6-9134-239a750f414c latest"
@@ -142,7 +143,7 @@ fi
 imageJson=$(sdc-imgadm get $imageUuid 2>/dev/null || true)
 if [[ -z "$imageJson" ]]; then
     echo "Importing image $imageUuid from updates.jo"
-    sdc-imgadm import $imageUuid -S https://updates.joyent.com?channel=$channel
+    sdc-imgadm import $imageUuid -S https://updates.tritondatacenter.com?channel=$channel
     imageJson=$(sdc-imgadm get $imageUuid)
 else
     echo "Already have image $imageUuid in local IMGAPI"

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,16 +22,16 @@ SmartOS zone or a KVM machine image) plus [the metadata for the image (called
 the "manifest")](#image-manifests). The following API instances and tools
 are relevant for managing images in and for SmartOS and SDC.
 
-The Joyent IMGAPI (<https://images.joyent.com>) is the central repository
-of Joyent-vetted base images for usage in SmartOS. (Images from software
-vendors may exist here, but are still vetted by Joyent.) All images here are
+The SmartoS IMGAPI (<https://images.smartos.org>) is the central repository
+of vetted base images for usage in SmartOS. (Images from software
+vendors may exist here, but are still vetted.) All images here are
 public -- no read auth, no private images. SmartOS' `imgadm` version 2
 is configured to use this image repository by default. SDC's operator portal
 (a.k.a. adminui) is configured by default to use this repository from which
 to import images.
 
-Administration of <https://images.joyent.com> is via the `joyent-imgadm`
-tool (currently available in `git@github.com:joyent/sdc-imgapi-cli.git`).
+Administration of <https://images.smartos.org> is via the `images-imgadm`
+tool (currently available in `git@github.com:TritonDataCenter/sdc-imgapi-cli.git`).
 
 There is an IMGAPI in each SDC datacenter that manages images available in
 that datacenter. "IMGAPI" without scoping typically refers to this IMGAPI
@@ -40,8 +40,8 @@ for provisioning in that DC. The provisioning process will lazily
 `zfs receive` images on CNs as necessary -- streaming from the IMGAPI
 (`imgadm` on that machine handles that). IMGAPI supports private images,
 customer-owned images, etc. Cloud API speaks to IMGAPI for its
-['/images'](https://mo.joyent.com/docs/cloudapi/master/#images) and legacy
-['/datasets'](https://mo.joyent.com/docs/cloudapi/master/#datasets)
+['/images'](https://engdoc.tritondatacenter.com/docs/cloudapi/master/#images) and legacy
+['/datasets'](https://engdoc.tritondatacenter.com/docs/cloudapi/master/#datasets)
 endpoints.
 
 
@@ -128,7 +128,7 @@ A summary of fields (details are provided below):
 the [AddImageIcon](#AddImageIcon) and [DeleteImageIcon](#DeleteImageIcon)
 endpoints. `disabled` can be modified via the [DisableImage](#DisableImage)
 and [EnableImage](#EnableImage) endpoints. `public` cannot be set false for
-an image on the "public mode" IMGAPI, e.g. <https://images.joyent.com>.
+an image on the "public mode" IMGAPI, e.g. <https://images.smartos.org>.
 
 
 ## Manifest: v
@@ -156,8 +156,7 @@ UUID. (2) SDC operators can use the [AdminImportImage](#AdminImportImage)
 to add an image with a specified UUID. In the latter case it is the
 responsibility of the operator to ensure a given UUID is not duplicated,
 or refers to different image data between separate clouds. A common case
-for the latter is importing "core" Joyent-provided images from
-<https://images.joyent.com>.
+for the latter is importing "core" images from <https://images.smartos.org>.
 
 
 ## Manifest: urn
@@ -209,7 +208,7 @@ semver](http://semver.org/#spec-item-10). However, it wasn't until OS-5798 that
 Therefore a **warning**: do not use '+' in an image version until you know that
 the minimum platform version for any server in your target DC(s) is greater than
 or equal to 20161118T231131Z (when OS-5798 was
-[integrated](https://github.com/joyent/smartos-live/commit/fc5816a)).
+[integrated](https://github.com/TritonDataCenter/smartos-live/commit/fc5816a)).
 
 
 ## Manifest: description
@@ -272,7 +271,7 @@ Possible `error.code` values from current SmartDataCenter and SmartOS:
 
 | error.code            | Details                                                                                                                                                                                                                                                                                                                                         |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| PrepareImageDidNotRun | This typically means that the target KVM VM (e.g. Linux) has old guest tools that pre-date the image creation feature. Guest tools can be upgraded with installers at <https://download.joyent.com/pub/guest-tools/>. Other possibilities are: a boot time greater than the 5 minute timeout or a bug or crash in the image preparation script. |
+| PrepareImageDidNotRun | This typically means that the target KVM VM (e.g. Linux) has old guest tools that pre-date the image creation feature. Guest tools can be upgraded with installers at <https://download.tritondatacenter.com/pub/guest-tools/>. Other possibilities are: a boot time greater than the 5 minute timeout or a bug or crash in the image preparation script. |
 | VmHasNoOrigin         | Origin image data could not be found for the VM. Either the link to the image from which the VM was created has been broken (e.g. via 'zfs promote' or migration, see SYSOPS-6491) or there is some problem in either the 'image_uuid' value from `vmadm get` or in imgadm's DB of manifest info for that image.                                |
 | NotSupported          | Indicates an error due to functionality that isn't currently supported. One example is that custom image creation of a VM based on a custom image isn't currently supported.                                                                                                                                                                    |
 
@@ -312,7 +311,7 @@ copy an image between two datacenters in the same cloud and persist the
 `published_at`. (2) SDC operators can use the
 [AdminImportImage](#AdminImportImage) to add an image with a specified uuid
 and `published_at`. A common case for the latter is importing "core"
-Joyent-provided images from <https://images.joyent.com>.
+images from <https://images.smartos.org>.
 
 
 ## Manifest: type
@@ -793,9 +792,9 @@ See [Errors](#errors) section above.
 
 ### Example
 
-Raw curl (from images.joyent.com):
+Raw curl (from images.smartos.org):
 
-    $ curl -kisS https://images.joyent.com/images | json
+    $ curl -kisS https://images.smartos.org/images | json
     HTTP/1.1 200 OK
     Date: Tue, 08 Jan 2013 01:07:25 GMT
     Content-Type: application/json
@@ -828,15 +827,15 @@ Raw curl (from images.joyent.com):
         "description": "Base template to build other templates on",
     ...
 
-CLI tool (from images.joyent.com):
+CLI tool (from images.smartos.org):
 
-    $ joyent-imgadm list
+    $ images-imgadm list
     UUID                                  NAME           VERSION  OS       STATE   PUBLISHED
     febaa412-6417-11e0-bc56-535d219f2590  smartos        1.3.12   smartos  active  2011-04-11
     7456f2b0-67ac-11e0-b5ec-832e6cf079d5  nodejs         1.1.3    smartos  active  2011-04-15
     ...
 
-    $ joyent-imgadm list name=~base   # filter on substring in name
+    $ images-imgadm list name=~base   # filter on substring in name
     UUID                                  NAME    VERSION  OS       STATE   PUBLISHED
     8418dccc-c9c6-11e1-91f4-5fb387d839c5  base    1.7.0    smartos  active  2012-07-09
     d0eebb8e-c9cb-11e1-8762-2f01c4acd80d  base64  1.7.0    smartos  active  2012-07-10
@@ -898,16 +897,16 @@ See [Errors](#errors) section above.
 
 ### Example
 
-Raw curl (from images.joyent.com):
+Raw curl (from images.smartos.org):
 
-    $ curl -sS https://images.joyent.com/images/01b2c898-945f-11e1-a523-af1afbe22822
+    $ curl -sS https://images.smartos.org/images/01b2c898-945f-11e1-a523-af1afbe22822
     {
       "uuid": "01b2c898-945f-11e1-a523-af1afbe22822",
     ...
 
-CLI tool (from images.joyent.com):
+CLI tool (from images.smartos.org):
 
-    $ joyent-imgadm get 01b2c898-945f-11e1-a523-af1afbe22822
+    $ images-imgadm get 01b2c898-945f-11e1-a523-af1afbe22822
     {
       "uuid": "01b2c898-945f-11e1-a523-af1afbe22822",
     ...
@@ -990,13 +989,13 @@ For request validation errors, see [Errors](#errors) section above.
 
 ### Example
 
-Raw curl (from images.joyent.com):
+Raw curl (from images.smartos.org):
 
-    $ curl -kfsS https://images.joyent.com/images/01b2c898-945f-11e1-a523-af1afbe22822/file -o file.bz2
+    $ curl -kfsS https://images.smartos.org/images/01b2c898-945f-11e1-a523-af1afbe22822/file -o file.bz2
 
-CLI tool (from images.joyent.com):
+CLI tool (from images.smartos.org):
 
-    $ joyent-imgadm get-file 01b2c898-945f-11e1-a523-af1afbe22822 -O
+    $ images-imgadm get-file 01b2c898-945f-11e1-a523-af1afbe22822 -O
     100% [=============================]  time 43.4s  eta 0.0s
     Saved "01b2c898-945f-11e1-a523-af1afbe22822.bz2".
 
@@ -1043,7 +1042,7 @@ Raw curl:
 
 CLI tool:
 
-    $ joyent-imgadm get-icon 01b2c898-945f-11e1-a523-af1afbe22822 -O
+    $ images-imgadm get-icon 01b2c898-945f-11e1-a523-af1afbe22822 -O
     100% [=============================]  time 0.4s  eta 0.0s
     Saved "01b2c898-945f-11e1-a523-af1afbe22822.png".
 
@@ -1079,7 +1078,7 @@ See [Errors](#errors) section above.
 
 CLI tool:
 
-    $ joyent-imgadm delete-icon 01b2c898-945f-11e1-a523-af1afbe22822
+    $ images-imgadm delete-icon 01b2c898-945f-11e1-a523-af1afbe22822
     Deleted icon from image 01b2c898-945f-11e1-a523-af1afbe22822
 
 Raw API tool:
@@ -1096,7 +1095,7 @@ with 'account=$UUID' and without. The former is what cloudapi uses to ask on
 behalf of a particular authenticated account. The latter is for operator-only
 querying.
 
-For IMGAPI servers that support image channels (e.g. updates.joyent.com)
+For IMGAPI servers that support image channels (e.g. updates.tritondatacenter.com)
 
 ### Inputs
 
@@ -1116,9 +1115,9 @@ See [Errors](#errors) section above.
 
 ### Example
 
-CLI tool (from images.joyent.com):
+CLI tool (from images.smartos.org):
 
-    $ joyent-imgadm delete 69d8bd69-db68-a54c-bec5-8c934822cfa9
+    $ images-imgadm delete 69d8bd69-db68-a54c-bec5-8c934822cfa9
     Deleted image 69d8bd69-db68-a54c-bec5-8c934822cfa9
 
 Raw API tool (from an SDC's IMGAPI):
@@ -2181,7 +2180,7 @@ AddImageFile and ActivateImage calls after the AdminImportImage.
 ## AdminImportRemoteImage (POST /images/:uuid?action=import-remote)
 
 Import an image from another IMGAPI repository. This is typically used for
-importing an image from <https://images.joyent.com>, but can be used for any
+importing an image from <https://images.smartos.org>, but can be used for any
 other valid Image repository. It is mainly a convenience method to allow IMGAPI
 to execute the five import steps (get manifest, get file, import manifest,
 add file, activate image) on the user's behalf.
@@ -2219,7 +2218,7 @@ See [Errors](#errors) section above.
 
 Raw API tool:
 
-    $ sdc-imgapi /images/01b2c898-945f-11e1-a523-af1afbe22822?action=import-remote&source=https://images.joyent.com -X POST
+    $ sdc-imgapi /images/01b2c898-945f-11e1-a523-af1afbe22822?action=import-remote&source=https://images.smartos.org -X POST
     HTTP/1.1 200 OK
     workflow-api: http://workflow.coal.joyent.us
     content-type: application/json
@@ -2237,7 +2236,7 @@ Raw API tool:
 
 CLI tool:
 
-    $ sdc-imgadm import 84cb7edc-3f22-11e2-8a2a-3f2a7b148699 -S https://images.joyent.com
+    $ sdc-imgadm import 84cb7edc-3f22-11e2-8a2a-3f2a7b148699 -S https://images.smartos.org
     Imported image 84cb7edc-3f22-11e2-8a2a-3f2a7b148699 (base, 1.8.4, state=active)
 
 
@@ -2252,7 +2251,7 @@ data.
 
 This endpoint is intended to only be called by operators. Typically it is
 called by the 'pull-image' workflow defined in
-[sdc-docker](https://github.com/joyent/sdc-docker).
+[sdc-docker](https://github.com/TritonDataCenter/sdc-docker).
 
 ### Inputs
 
@@ -2366,7 +2365,7 @@ See [Errors](#errors) section above.
 
 ### Example
 
-With [imgapi-cli tools](https://github.com/joyent/imgapi-cli):
+With [imgapi-cli tools](https://github.com/TritonDataCenter/imgapi-cli):
 
     $ updates-imgadm change-stor manta f342dcdc-e179-11e5-98a0-0f71c4796729
     Changed image f342dcdc-e179-11e5-98a0-0f71c4796729 (sapi@master-20160303T195116Z-g7fbf8d7) stor to "manta"
@@ -2458,7 +2457,7 @@ channels.
 Each relevant IMGAPI endpoint has a `?channel=<channel>` query param to work
 with images in that channel. Without it the server's configured default channel
 is implied. The [IMGAPI
-client](https://mo.joyent.com/node-sdc-clients/blob/master/lib/imgapi.js) takes
+client](https://engdoc.tritondatacenter.com/node-sdc-clients/blob/master/lib/imgapi.js) takes
 a new `channel` constructor option. Image manifests have a new "channels"
 field that is an array of the channel names to which the image belongs.
 
@@ -2469,8 +2468,8 @@ existing image is added to additional channels via
 repository until it is removed from its last channel.
 
 The current canonical example of an IMGAPI server using channels is the
-SmartDataCenter updates server (<https://updates.joyent.com>). The
-[`updates-imgadm`](https://mo.joyent.com/imgapi-cli/blob/channels/bin/updates-imgadm)
+SmartDataCenter updates server (<https://updates.tritondatacenter.com>). The
+[`updates-imgadm`](https://engdoc.tritondatacenter.com/imgapi-cli/blob/channels/bin/updates-imgadm)
 CLI takes a `-C <channel>` option or `UPDATES_IMGADM_CHANNEL=<channel>`
 environment variable to specify the channel. Additionally on a SmartDataCenter
 headnode the `updates-imgadm` will default to the DC's configured update
@@ -2512,9 +2511,9 @@ CLI tool:
     staging  -        builds for testing in staging in prep for production release
     release  -        release gold bits
 
-Raw curl (from updates.joyent.com):
+Raw curl (from updates.tritondatacenter.com):
 
-    $ curl -kisS https://updates.joyent.com/channels
+    $ curl -kisS https://updates.tritondatacenter.com/channels
     HTTP/1.1 200 OK
     Content-Type: application/json
     Content-Length: 280

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ SmartOS zone or a KVM machine image) plus [the metadata for the image (called
 the "manifest")](#image-manifests). The following API instances and tools
 are relevant for managing images in and for SmartOS and SDC.
 
-The SmartoS IMGAPI (<https://images.smartos.org>) is the central repository
+The SmartOS IMGAPI (<https://images.smartos.org>) is the central repository
 of vetted base images for usage in SmartOS. (Images from software
 vendors may exist here, but are still vetted.) All images here are
 public -- no read auth, no private images. SmartOS' `imgadm` version 2

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -19,29 +19,29 @@ There are two main types of IMGAPI:
 
 2. `standalone`: A standalone IMGAPI, that runs independent of a Triton
    DataCenter. These are configured with `mode === "public"` (for public images,
-   example "images.joyent.com") or `mode === "private"` (for repos with private
-   images, example "updates.joyent.com"). These serve HTTPS over a public
+   example "images.smartos.org") or `mode === "private"` (for repos with private
+   images, example "updates.tritondatacenter.com"). These serve HTTPS over a public
    network (via haproxy for SSL termination and possible load balancing, to one
    or more node.js IMGAPI processes). They are typically configured to use HTTP
    Signature auth (like Triton's CloudAPI and Manta's web API) for any write
    endpoints.
 
-# Image
+## Image
 
 Both types of IMGAPI instances use "imgapi" images built from sdc-imgapi.git,
-released to [Joyent's Updates Image repository](https://updates.joyent.com).
+released to [Triton's Updates Image repository](https://updates.tritondatacenter.com).
 
 
-# DC-Mode Setup
+## DC-Mode Setup
 
 A DC-mode IMGAPI instance is setup via standard Triton DataCenter headnode
 setup. See
-[headnode.sh](https://github.com/joyent/sdc-headnode/blob/master/scripts/headnode.sh).
+[headnode.sh](https://github.com/TritonDataCenter/sdc-headnode/blob/master/scripts/headnode.sh).
 
-## DC-mode setup: add an external NIC
+### DC-mode setup: add an external NIC
 
-For a DC-mode IMGAPI to import images -- e.g. from images.joyent.com to add base
-images for users of the DC, or from updates.joyent.com for updating the Triton
+For a DC-mode IMGAPI to import images -- e.g. from images.smartos.org to add base
+images for users of the DC, or from updates.tritondatacenter.com for updating the Triton
 DC -- the IMGAPI instance requires an external NIC. The instance is firewalled
 to only allow outgoing connections. The external NIC can be added (and to the
 adminui instance) via:
@@ -49,7 +49,7 @@ adminui instance) via:
     sdcadm post-setup common-external-nics
 
 
-## DC-mode setup: connect to Manta
+### DC-mode setup: connect to Manta
 
 For durable image storage (and to enable image creation which intentionally
 fails without durable storage), a DC-mode IMGAPI instance needs to be given
@@ -68,7 +68,7 @@ from inside the imgapi zone):
 (Dev Note: Longer term this responsibility should move to a `sdcadm post-setup ...` command.)
 
 
-## DC-mode setup: enable custom image creation without Manta
+### DC-mode setup: enable custom image creation without Manta
 
 (This step is optional, and typically solely for development.)
 
@@ -94,12 +94,12 @@ When the 'config-agent' running in the imgapi zone picks up this change
 section](#configuration) above).
 
 
-# Standalone Setup
+## Standalone Setup
 
 A standalone IMGAPI instance is just a regular instance. However two reasons
 mean we can't use stock `triton` to provision one:
 
-- We use 'imgapi' images from updates.joyent.com, which can only be imported
+- We use 'imgapi' images from updates.tritondatacenter.com, which can only be imported
   to a DC by an operator.
   Dev Note: Eventually this could move to custom image builds by the user that
   owns the imgapi instance. Preferably this would be via a `triton build`
@@ -113,7 +113,7 @@ two instances are writing to the same Manta area, they could cause conflicts
 in the image files and backups stored there.
 
 
-## Standalone Setup Step 1: create instance
+### Standalone Setup Step 1: create instance
 
 To create new standalone IMGAPI instance, use
 [imgapi-standalone-create](../bin/imgapi-standalone-create). It needs to be
@@ -124,7 +124,7 @@ run from the DC's headnode global zone.
 For example:
 
     cd /var/tmp
-    curl -kO https://raw.githubusercontent.com/joyent/sdc-imgapi/master/bin/imgapi-standalone-create
+    curl -kO https://raw.githubusercontent.com/TritonDataCenter/sdc-imgapi/master/bin/imgapi-standalone-create
     chmod +x imgapi-standalone-create
 
     # A play IMGAPI in COAL using a local 'trentm' COAL account and
@@ -135,21 +135,21 @@ For example:
         -m mantaBaseDir=tmp/images \
         trentm latest sample-2G myimages0
 
-    # An deployment of images.joyent.com might look like this:
+    # An deployment of images.smartos.org might look like this:
     ./imgapi-standalone-create \
         -m mantaUrl=https://us-east.manta.joyent.com \
         -m mantaUser=joyops \
-        -m mantaBaseDir=images.joyent.com \
+        -m mantaBaseDir=images.smartos.org \
         -t triton.cns.services=imagesjo \
         joyops latest g4-highcpu-2G imagesjo0
 
 The `-m` option adds metadata. A set of metadata keys are supported setup config
 vars (see [Standalone Setup Configuration](#standalone-setup-configuration)
 below). The `-t` option adds an instance tag -- in this case to use
-[CNS](https://docs.joyent.com/public-cloud/network/cns).
+[CNS](https://docs.tritondatacenter.com/public-cloud/network/cns).
 
 
-## Standalone Setup Step 2: edit config
+### Standalone Setup Step 2: edit config
 
 After creation, one may edit the generated config file at
 "/data/imgapi/etc/imgapi.config.json" manually. Afterwards, remember to
@@ -159,7 +159,7 @@ restart the imgapi service:
     svcadm restart imgapi
 
 
-## Standalone Setup Step 3: add imgapi instance key to account
+### Standalone Setup Step 3: add imgapi instance key to account
 
 Every standalone IMGAPI instance creates its own "instance key" -- an SSH key
 to be used for authenticated access to Manta, if relevant. If configuring
@@ -180,7 +180,7 @@ listing keys it to check, it will look something like this:
     b3:f0:a1:6c:32:3b:47:63:ae:6e:57:22:74:71:d4:bd  trentm
 
 
-## Standalone Setup Step 4: restore data from backup
+### Standalone Setup Step 4: restore data from backup
 
 The setup is not complete until
 [imgapi-standalone-restore](../bin/imgapi-standalone-restore) is run. This will
@@ -196,7 +196,7 @@ data *to* the backup. Even if not backing up `imgapi-standalone-status` will
 report a problem if it hasn't been successfully run once.
 
 
-## Standalone Setup Step 5: set TLS cert
+### Standalone Setup Step 5: set TLS cert
 
 This step is optional.
 
@@ -209,7 +209,7 @@ certificate you'd like to use, it can be installed as follows:
 Dev note: Eventually we hope to support Let's Encrypt.
 
 
-## Standalone Setup Step 6: add authkeys for signature auth
+### Standalone Setup Step 6: add authkeys for signature auth
 
 This step is optional.
 
@@ -225,7 +225,7 @@ way to do that is to add "$username.keys" files in the IMGAPI's Manta area at:
 
 For example:
 
-    $ mget /joyops/stor/images.joyent.com/authkeys/trentm.keys
+    $ mget /joyops/stor/images.smartos.org/authkeys/trentm.keys
     ssh-rsa AAAAB3NzaC1yc2EAAAABIwAA...
 
 The IMGAPI server periodically (once per hour) syncs changes from that Manta
@@ -235,26 +235,26 @@ area and updates its auth info. Or for the lazy one can do either of:
 
     # The following require already being setup for auth.
     IMGAPI_CLI_URL=https://myimages.com imgapi-cli reload-auth-keys
-    joyent-imgadm reload-auth-keys      # custom CLI for images.joyent.com
-    updates-imgadm reload-auth-keys     # custom CLI for updates.joyent.com
+    images-imgadm reload-auth-keys      # custom CLI for images.smartos.org
+    updates-imgadm reload-auth-keys     # custom CLI for updates.tritondatacenter.com
 
 This isn't the only place that authkeys can be added. See the
 [Authentication](#authentication) section below for full details.
 
 
-## Standalone Setup Step 7: set CNS service tag
+### Standalone Setup Step 7: set CNS service tag
 
 This step is optional.
 
 A nice way to setup DNS for a standalone IMGAPI instance is to use
-[CNS](https://docs.joyent.com/public-cloud/network/cns), if available in
+[CNS](https://docs.tritondatacenter.com/public-cloud/network/cns), if available in
 your Triton DC. Set the `triton.cns.services` tag on your instance:
 
     triton inst tag set -w myimages0 triton.cns.services=myimages
 
 and CNS will create a service ("svc") DNS name:
 
-    $ triton -p joyentsw-sw1 inst get imagesjo0 | json dns_names
+    $ triton -p tritonsw inst get imagesjo0 | json dns_names
     [
       "0370c8fc-7f73-11e6-a160-7f089df626c7.inst.f3fabce8-7f72-11e6-98f8-6f6f85da7472.us-sw-1.triton.zone",
       "myimages0.inst.f3fabce8-7f72-11e6-98f8-6f6f85da7472.us-west-1.triton.zone",
@@ -270,7 +270,7 @@ Then, even if your instance is recycled and replaced, DNS will still work.
 And when imgapi supports multiple instances (for HA), DNS will map to all your
 instances using the "myimages" cns tag.
 
-## Standalone Setup Step 8: configure downstream imgapi
+### Standalone Setup Step 8: configure downstream imgapi
 
 If you have not completed step 5, the instance will be using a self-signed
 certificate. In this case, for testing purposes you may wish to configure
@@ -280,7 +280,7 @@ for example:
     $ service=$(sdc-sapi /services?name=imgapi | json -H 0.uuid)
     $ sapiadm update $service metadata.IMGAPI_ALLOW_INSECURE=true
 
-# Update
+## Update
 
 DC-mode:
 
@@ -298,7 +298,7 @@ isn't yet a part of CloudAPI).
 For example:
 
     cd /var/tmp
-    curl -kO https://raw.githubusercontent.com/joyent/sdc-imgapi/master/bin/imgapi-standalone-reprovision
+    curl -kO https://raw.githubusercontent.com/TritonDataCenter/sdc-imgapi/master/bin/imgapi-standalone-reprovision
     chmod +x imgapi-standalone-reprovision
 
     ./imgapi-standalone-reprovision 98cf10d4-7550-11e6-8930-ef291247b988 latest
@@ -308,13 +308,13 @@ This will handle importing the identified 'imgapi' image to the DC, tweaking
 its permissions, and reprovisioning the instance to the new image.
 
 
-# Key rotation
+## Key rotation
 
 Both DC-mode and standalone IMGAPI instances use an SSH key to talk to Manta
 for file storage (if configured to use Manta). This section describes how
 to rotate that key.
 
-## Key rotation: DC-mode
+### Key rotation: DC-mode
 
 A DC-mode IMGAPI that is configured to use Manta is setup in one of two ways:
 
@@ -336,7 +336,7 @@ In both cases the IMGAPI key can be rotated by re-running the script:
     imgapi-external-manta-setup <manta-url> <manta-user> <path-to-new-priv-key> | bunyan
 
 
-## Key rotation: Standalone
+### Key rotation: Standalone
 
 Login to the instance and run:
 
@@ -350,7 +350,7 @@ wait until that key is available and then update the imgapi service as
 appropriate.
 
 
-# Health
+## Health
 
 DC-mode:
 
@@ -368,7 +368,7 @@ Standalone:
     imgapi-standalone-status [-h] [-v]
 
 
-# Backup and Recovery
+## Backup and Recovery
 
 DC-mode: nothing currently
 
@@ -384,7 +384,7 @@ Recovery from backup is exactly the setup process described above: read the
 script is the part that restores the local data from backup.
 
 
-# Background processes
+## Background processes
 
 DC-mode IMGAPI has the following background processes:
 
@@ -412,7 +412,7 @@ following background processes:
    Manta.
 
 
-# Configuration
+## Configuration
 
 An IMGAPI process is configured via two files:
 
@@ -427,7 +427,7 @@ An IMGAPI process is configured via two files:
     A DC-mode config file is rendered by the `config-agent` service -- rendered
     from the template at "sapi_templates/imgapi/template" and instance config
     from the SAPI GetConfig endpoint
-    (https://github.com/joyent/sdc-sapi/blob/master/docs/index.md). See
+    (https://github.com/TritonDataCenter/sdc-sapi/blob/master/docs/index.md). See
     "SAPI Configuration" below.
 
     A standalone IMGAPI's config file is initially rendered by the
@@ -450,7 +450,7 @@ For example: if providing `manta`, one must provide the whole `manta` object.
 | serverName                   | String        | imgapi/$version   | Name of the HTTP server. This value is present on every HTTP response in the 'Server' header. |
 | logLevel                     | String/Number | debug             | Level at which to log. One of the supported Bunyan log levels. This is overridden by the `-d,--debug` switch. |
 | maxSockets                   | Number        | 100               | Maximum number of sockets for external API calls |
-| mode                         | String        | public            | One of 'public' (default, running as a public server e.g. images.joyent.com), 'private' (a ironically "public" server that only houses images marked `public=false`), or 'dc' (running as the IMGAPI in a Triton DataCenter). |
+| mode                         | String        | public            | One of 'public' (default, running as a public server e.g. images.smartos.org), 'private' (a ironically "public" server that only houses images marked `public=false`), or 'dc' (running as the IMGAPI in a Triton DataCenter). |
 | datacenterName               | String        | -                 | Name of the Triton DataCenter on which IMGAPI is running. Only relevant if `mode === "dc"`. |
 | serviceName                  | String        | -                 | The name of the service. Only relevant if `mode === "dc"`. |
 | instanceUuid                 | String        | -                 | The instance UUID. Only relevant if `mode === "dc"`. |
@@ -462,7 +462,7 @@ For example: if providing `manta`, one must provide the whole `manta` object.
 | allowLocalCreateImageFromVm  | Boolean       | false             | Whether to allow CreateImageFromVm using local storage (i.e. if no manta storage is configured). This should only be enabled for testing. For SDC installations of IMGAPI `"IMGAPI_ALLOW_LOCAL_CREATE_IMAGE_FROM_VM": true` can be set on the metadata for the 'imgapi' SAPI service to enable this. |
 | allowInsecure                | Boolean       | false             | Whether to allow insecure connection to another IMGAPI instance when importing from it.  This should only be enabled for testing. For SDC installations of IMGAPI `"IMGAPI_ALLOW_INSECURE": true` can be set on the metadata for the 'imgapi' SAPI service to enable this. |
 | minImageCreationPlatform     | Array         | see defaults.json | The minimum platform version, `["<sdc version>", "<platform build timestamp>"]`, on which the proto VM for image creation must reside. This is about the minimum platform with sufficient `imgadm` tooling. This is used as an early failure guard for [CreateImageFromVm](#CreateImageFromVm). |
-| authType                     | String        | signature         | One of 'none' or 'signature' ([HTTP Signature auth](https://github.com/joyent/node-http-signature)). |
+| authType                     | String        | signature         | One of 'none' or 'signature' ([HTTP Signature auth](https://github.com/TritonDataCenter/node-http-signature)). |
 | authKeys                     | Object        | -                 | Optional. A mapping of username to an array of ssh public keys. Only used for HTTP signature auth (`config.authType === "signature"`). |
 | databaseType                 | String        | local             | The database backend type to use. One of "local" or "moray". The latter is what is typically used in-DC. |
 | storageTypes                 | Array         | ["local"]         | The set of available storage mechanisms for the image *files*. There must be at least one. Supported values are "local" and "manta". See the [Image file storage](#image-file-storage) section for discussion. |
@@ -507,7 +507,7 @@ the merged and computed config object values. Examples:
         "authType": "signature",
     ...
 
-## SAPI Configuration
+### SAPI Configuration
 
 DC-mode IMGAPI is configured via "metadata" on the "imgapi" SAPI service.
 See [the config template](../sapi_manifests/imgapi/template) for the
@@ -517,11 +517,11 @@ authoritative details.
 | --------------------------------------- | ------- | ------- | ----------- |
 | IMGAPI_ALLOW_LOCAL_CREATE_IMAGE_FROM_VM | Boolean | false   | Set this to allow image creation even when the DC is not setup to use a Manta. This is useful for development. See [the setup section](#dc-mode-setup-enable-custom-image-creation-without-manta). |
 | IMGAPI_MANTA_\*                         | various | -       | These are typically setup by the `imgapi[-external]-manta-setup` scripts. See the [DC-mode setup: connect to Manta](#dc-mode-setup-connect-to-manta) section |
-| docker_registry_insecure                | Boolean | false   | See <https://github.com/joyent/triton/blob/master/docs/operator-guide/configuration.md#sdc-application-configuration> |
-| http_proxy                              | String  | -       | See <https://github.com/joyent/triton/blob/master/docs/operator-guide/configuration.md#sdc-application-configuration> |
+| docker_registry_insecure                | Boolean | false   | See <https://github.com/TritonDataCenter/triton/blob/master/docs/operator-guide/configuration.md#sdc-application-configuration> |
+| http_proxy                              | String  | -       | See <https://github.com/TritonDataCenter/triton/blob/master/docs/operator-guide/configuration.md#sdc-application-configuration> |
 | IMGAPI_URL_FROM_DATACENTER              | Object  | -       | See [x-DC Image Copying](#x-dc-image-copying) description. |
 
-## Standalone Setup Configuration
+### Standalone Setup Configuration
 
 A standalone IMGAPI instance's config is first written at initial setup by
 [imgapi-standalone-gen-setup-config](../bin/imgapi-standalone-gen-setup-config)
@@ -538,9 +538,9 @@ These are called "setup config vars". At time of writing they are (see
 | mantaUser     | manta.user |
 | mantaBaseDir  | manta.baseDir |
 | mantaInsecure | manta.insecure |
-| channels      | channels; This may also by the special value `standard`, which will be substituted by the "standard" channels (a set of channels used by updates.joyent.com). |
+| channels      | channels; This may also by the special value `standard`, which will be substituted by the "standard" channels (a set of channels used by updates.tritondatacenter.com). |
 
-## x-DC Image Copying
+### x-DC Image Copying
 
 It is possible to configure IMGAPI to allow users to copy images from one
 datacenter to another.
@@ -552,7 +552,7 @@ allowed to copy into.
 The configuration will be a JSON object, which contains a mapping of the dc
 short name or the IMGAPI **admin** url where IMGAPI is listening. Note that the
 short dc name should match what is shown via:
-[CloudAPI ListDatacenters](https://apidocs.joyent.com/cloudapi/#ListDatacenters).
+[CloudAPI ListDatacenters](https://apidocs.tritondatacenter.com/cloudapi/#ListDatacenters).
 
 For example, to allow us-east-1 to copy images into both us-sw-1 and us-west-1
 you would run the following SAPI configuration command:
@@ -565,7 +565,7 @@ you would run the following SAPI configuration command:
 Then restart config-agent in the imgapi zone (or wait until imgapi notices the
 config has changed, at which point imgapi will then restart itself).
 
-# Storage
+## Storage
 
 There are two possible storage mechanisms for the (possibly large) image files
 (and image icon files). The storage mechanisms used are configured via
@@ -601,7 +601,7 @@ Storage types are:
 
    Examples:
 
-        /jim/stor/images.joyent.com/...
+        /jim/stor/images.smartos.org/...
         /cloudops/stor/imgapi/us-test-1/...
 
 2. `local`: Files are stored at the local "/data/imgapi/images/..." (possibly
@@ -611,12 +611,12 @@ Storage types are:
 Configuring for Manta storage is preferred because file storage is then durable.
 For in-DC IMGAPI instances, Manta storage is *required* for user custom image
 creation, i.e. CloudAPI's
-[CreateImageFromMachine](http://apidocs.joyent.com/cloudapi/#CreateImageFromMachine),
+[CreateImageFromMachine](http://apidocs.tritondatacenter.com/cloudapi/#CreateImageFromMachine),
 unless [overriden](#dc-mode-setup-enable-custom-image-creation-without-manta).
 
 For DC-mode imgapi instances, the
-[`<imgapi-zone>:/opt/smartdc/imgapi/bin/imgapi-manta-setup`](https://github.com/joyent/sdc-imgapi/blob/master/bin/imgapi-manta-setup)
-and [`<imgapi-zone>:/opt/smartdc/imgapi/bin/imgapi-external-manta-setup`](https://github.com/joyent/sdc-imgapi/blob/master/bin/imgapi-external-manta-setup)
+[`<imgapi-zone>:/opt/smartdc/imgapi/bin/imgapi-manta-setup`](https://github.com/TritonDataCenter/sdc-imgapi/blob/master/bin/imgapi-manta-setup)
+and [`<imgapi-zone>:/opt/smartdc/imgapi/bin/imgapi-external-manta-setup`](https://github.com/TritonDataCenter/sdc-imgapi/blob/master/bin/imgapi-external-manta-setup)
 scripts are intended for use in setting up to use a Manta. (Longer term this
 responsibility should move to a `sdcadm post-setup ...` command.)
 
@@ -637,7 +637,7 @@ Manta (useful for development and debugging):
     rootDir=$(node /opt/smartdc/imgapi/lib/config.json manta.rootDir)
     mls $rootDir
 
-# Authentication
+## Authentication
 
 IMGAPI supports two authentication modes:
 
@@ -646,7 +646,7 @@ IMGAPI supports two authentication modes:
 2. No auth (`config.authType === "none"`). This is the typical configuration for
    DC-mode IMGAPI instances, which run on the "admin" network.
 
-## HTTP Signature auth
+### HTTP Signature auth
 
 To support HTTP signature authentication the server needs a mapping of
 usernames to an array of SSH public keys. There are three places those keys
@@ -676,7 +676,7 @@ can come from:
     [AdminReloadAuthKeys](#AdminReloadAuthKeys) endpoint to trigger a reload.
 
 
-# Logs
+## Logs
 
 | service/path         | where                  | notes |
 | -------------------- | ---------------------- | ----- |
@@ -689,7 +689,7 @@ can come from:
 | logadm               | /var/log/logadm.log               | standalone-mode only |
 
 
-## Log rotation and upload to Manta
+### Log rotation and upload to Manta
 
 Logs marked with an asterisk (\*) are rotated and uploaded to Manta.
 
@@ -697,9 +697,9 @@ DC-mode IMGAPIs' `logadm` rotates logs hourly to:
 
     /var/log/sdc/upload/$svc_$zonename_$timestamp.log
 
-and the [hermes](https://github.com/joyent/sdc-hermes) global zone agent
+and the [hermes](https://github.com/TritonDataCenter/sdc-hermes) global zone agent
 periodically uploads from there to Manta per [this
-configuration](https://github.com/joyent/sdc-sdc/blob/master/etc/logsets.json#L198),
+configuration](https://github.com/TritonDataCenter/sdc-sdc/blob/master/etc/logsets.json#L198),
 removing files after a period after upload.
 
 * * *
@@ -739,7 +739,7 @@ The improvements are:
   for analysis.
 
 
-## Log-related commands
+### Log-related commands
 
 Some possibly useful commands follow.
 Tail the imgapi log:
@@ -756,6 +756,6 @@ to tail *trace*-level logs of the imgapi service:
 
     bunyan -p imgapi
 
-# Metrics
+## Metrics
 
-IMGAPI exposes metrics via [node-triton-metrics](https://github.com/joyent/node-triton-metrics) on `http://<ADMIN_IP>:8881/metrics`
+IMGAPI exposes metrics via [node-triton-metrics](https://github.com/TritonDataCenter/node-triton-metrics) on `http://<ADMIN_IP>:8881/metrics`

--- a/etc/standalone/standard-channels.json
+++ b/etc/standalone/standard-channels.json
@@ -3,5 +3,5 @@
     {"name": "dev", "description": "main development branch builds", "default": true},
     {"name": "staging", "description": "staging for release branch builds before a full release"},
     {"name": "release", "description": "release bits"},
-    {"name": "support", "description": "Joyent-supported release bits"}
+    {"name": "support", "description": "MNX-supported release bits"}
 ]

--- a/lib/app.js
+++ b/lib/app.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright (c) 2018, Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
@@ -169,7 +170,8 @@ function getAuthMiddleware(app, config, passive) {
     } else if (config.authType === 'signature') {
         var httpSig = require('http-signature');
 
-        // Disallow HMAC key type to avoid joyent/node-http-signature#40
+        /*JSSTYLED*/
+        // Disallow HMAC key type to avoid TritonDataCenter/node-http-signature#40
         var VALID_ALGS = ['RSA-SHA1', 'RSA-SHA256', 'DSA-SHA1'];
 
         return function reqSignatureAuth(req, res, next) {
@@ -259,7 +261,7 @@ function formatJSON(req, res, body, cb) {
  * The Image API application.
  *
  * @param config {Object} The IMGAPI config. See
- *      <https://mo.joyent.com/docs/imgapi/master/#configuration>.
+ *      <https://engdoc.tritondatacenter.com/docs/imgapi/master/#configuration>.
  * @param log {Bunyan Logger instance}
  */
 function App(config, log) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -6,11 +6,12 @@
 
 /*
  * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
  * IMGAPI errors. Error responses follow
- * <https://mo.joyent.com/docs/eng/master/#error-handling>
+ * <https://engdoc.tritondatacenter.com/docs/eng/master/#error-handling>
  *
  * Test out an example errors response via:
  *

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "imgapi",
   "description": "Image API to manage images for Triton Data Center",
-  "version": "4.11.2",
-  "author": "Joyent (joyent.com)",
+  "version": "4.12.0",
+  "author": "MNX Cloud (mnxsolutions.com)",
   "private": true,
   "dependencies": {
     "assert-plus": "^1.0.0",
@@ -12,7 +12,7 @@
     "cmdln": "^3.2.1",
     "dashdash": "^1.10.0",
     "docker-registry-client": "^3.3.0",
-    "effluent-logger": "git+https://github.com/joyent/effluent-logger.git#d662f161a07f94045ad2afb45442931511c40e51",
+    "effluent-logger": "git+https://github.com/TritonDataCenter/effluent-logger.git#d662f161a07f94045ad2afb45442931511c40e51",
     "expiring-lru-cache": "^2.1.0",
     "extsprintf": "^1.2.0",
     "forkexec": "^1.1.0",
@@ -27,7 +27,7 @@
     "manta-sync": "^0.4.2",
     "memorystream": "^0.2.0",
     "mkdirp": "^0.3.5",
-    "moray": "git+https://github.com/joyent/node-moray.git#770efe6",
+    "moray": "git+https://github.com/TritonDataCenter/node-moray.git#770efe6",
     "nopt": "2.2.0",
     "once": "1.3.0",
     "passwd": "0.0.11",

--- a/test/access.public-test.js
+++ b/test/access.public-test.js
@@ -6,11 +6,12 @@
 
 /*
  * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
  * Test public vs. auth'd access to a 'public' mode IMGAPI (e.g.
- * https://images.joyent.com).
+ * https://images.smartos.org).
  */
 
 var format = require('util').format;
@@ -37,15 +38,15 @@ before(function (next) {
         url: process.env.IMGAPI_URL,
         agent: false
     };
-    if (process.env.IMGAPI_URL === 'https://images.joyent.com') {
-        assert.ok(process.env.JOYENT_IMGADM_USER,
-            'JOYENT_IMGADM_USER envvar is not set');
-        assert.ok(process.env.JOYENT_IMGADM_IDENTITY,
-            'JOYENT_IMGADM_IDENTITY envvar is not set');
-        options.user = process.env.JOYENT_IMGADM_USER;
+    if (process.env.IMGAPI_URL === 'https://images.smartos.org') {
+        assert.ok(process.env.IMAGES_IMGADM_USER,
+            'IMAGES_IMGADM_USER envvar is not set');
+        assert.ok(process.env.IMAGES_IMGADM_IDENTITY,
+            'IMAGES_IMGADM_IDENTITY envvar is not set');
+        options.user = process.env.IMAGES_IMGADM_USER;
         options.sign = imgapi.cliSigner({
-            keyId: process.env.JOYENT_IMGADM_IDENTITY,
-            user: process.env.JOYENT_IMGADM_USER
+            keyId: process.env.IMAGES_IMGADM_IDENTITY,
+            user: process.env.IMAGES_IMGADM_USER
         });
     } else {
         assert.fail('What no auth info!?');

--- a/test/admincreateimagefromvm.dc-test.js
+++ b/test/admincreateimagefromvm.dc-test.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
@@ -129,7 +130,7 @@ before(function (next) {
             self.client.getImage(TEST_IMAGE_UUID, function (err, img) {
                 if (err) {
                     console.error('error: the test image %s is not ' +
-                        'imported from images.joyent.com', TEST_IMAGE_UUID);
+                        'imported from images.smartos.org', TEST_IMAGE_UUID);
                 }
                 cb(err);
             });

--- a/test/adminimportimage.dc-test.js
+++ b/test/adminimportimage.dc-test.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
@@ -546,16 +547,16 @@ test('AdminImportImage zvol from local .dsmanifest', function (t) {
 
 
 /**
- * AdminImportImage scenario from images.joyent.com:
- * - get manifest from images.joyent.com/images/:uuid
+ * AdminImportImage scenario from images.smartos.org:
+ * - get manifest from images.smartos.org/images/:uuid
  * - AdminImportImage with that manifest
- * - AddImageFile *stream* from images.joyent.com/images/:uuid/file
+ * - AddImageFile *stream* from images.smartos.org/images/:uuid/file
  * - ActivateImage
  * - GetImage, GetImageFile checks
  * - clean up: delete it
  */
 if (!process.env.IMGAPI_TEST_OFFLINE)
-test('AdminImportImage from images.joyent.com', function (t) {
+test('AdminImportImage from images.smartos.org', function (t) {
     var self = this;
     // Pick a small one: minimal-32@15.2.0
     var uuid = '0764d78e-3472-11e5-8949-4f31abea4e05';
@@ -568,7 +569,7 @@ test('AdminImportImage from images.joyent.com', function (t) {
     var aImage;
 
     var imagesClient = new IMGAPI({
-        url: 'https://images.joyent.com',
+        url: 'https://images.smartos.org',
         agent: false
     });
 
@@ -697,20 +698,20 @@ test('AdminImportImage from images.joyent.com', function (t) {
 
 
 /**
- * AdminImportRemoteImage scenario from images.joyent.com. These steps happen
+ * AdminImportRemoteImage scenario from images.smartos.org. These steps happen
  * inside IMGAPI:
- * - get manifest from images.joyent.com/images/:uuid
+ * - get manifest from images.smartos.org/images/:uuid
  * - CreateImage with downloaded manifest
- * - AddImageFile *stream* from images.joyent.com/images/:uuid/file
+ * - AddImageFile *stream* from images.smartos.org/images/:uuid/file
  * - ActivateImage
  */
 if (!process.env.IMGAPI_TEST_OFFLINE)
-test('AdminImportRemoteImage from images.joyent.com', function (t) {
+test('AdminImportRemoteImage from images.smartos.org', function (t) {
     var self = this;
     // Pick a small one: minimal-32@15.2.0
     var uuid = '0764d78e-3472-11e5-8949-4f31abea4e05';
     var aImage;
-    var imagesUrl = 'https://images.joyent.com';
+    var imagesUrl = 'https://images.smartos.org';
 
     function importRemote(next) {
         self.client.adminImportRemoteImageAndWait(uuid, imagesUrl, {},
@@ -770,16 +771,17 @@ test('AdminImportRemoteImage from images.joyent.com', function (t) {
 
 
 /**
- * AdminImportRemoteImage from updates.joyent.com.
+ * AdminImportRemoteImage from updates.tritondatacenter.com.
  */
 if (!process.env.IMGAPI_TEST_OFFLINE)
-test('AdminImportRemoteImage from updates.joyent.com (dev chan)', function (t) {
+test('AdminImportRemoteImage from updates.tritondatacenter.com (dev chan)',
+    function (t) {
     var self = this;
     var name = 'assets';  // The 'assets' images are typically small.
     var sourceImage;
     var uuid;
     var aImage;
-    var source = 'https://updates.joyent.com';
+    var source = 'https://updates.tritondatacenter.com';
 
     function pickUuid(next) {
         var updates = new IMGAPI({url: source, agent: false, channel: 'dev'});

--- a/test/api-versions.public-test.js
+++ b/test/api-versions.public-test.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
@@ -64,7 +65,7 @@ before(function (next) {
         url: process.env.IMGAPI_URL,
         agent: false
     };
-    if (process.env.IMGAPI_URL === 'https://images.joyent.com') {
+    if (process.env.IMGAPI_URL === 'https://images.smartos.org') {
         assert.fail('Do not run the channels tests against images.jo.');
     }
     this.clients = {

--- a/test/channels.public-test.js
+++ b/test/channels.public-test.js
@@ -6,15 +6,16 @@
 
 /*
  * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
  * Test channels handling.
  *
  * We do this as a "public-test" rather than a "dc-test"
- * because practically speaking it is updates.joyent.com (a mode=private,
- * functionally equiv to mode=public) that has channels support and never the
- * mode=dc IMGAPI in SDC installations.
+ * because practically speaking it is updates.tritondatacenter.com (a
+ * mode=private, functionally equiv to mode=public) that has channels support
+ * and never the mode=dc IMGAPI in SDC installations.
  */
 
 var p = console.log;
@@ -68,7 +69,7 @@ before(function (next) {
         url: process.env.IMGAPI_URL,
         agent: false
     };
-    if (process.env.IMGAPI_URL === 'https://images.joyent.com') {
+    if (process.env.IMGAPI_URL === 'https://images.smartos.org') {
         assert.fail('Do not run the channels tests against images.jo.');
     } else {
         assert.fail('What no auth info!?');

--- a/test/ping.test.js
+++ b/test/ping.test.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
@@ -33,15 +34,15 @@ before(function (next) {
         url: process.env.IMGAPI_URL,
         agent: false
     };
-    if (process.env.IMGAPI_URL === 'https://images.joyent.com') {
-        assert.ok(process.env.JOYENT_IMGADM_USER,
-            'JOYENT_IMGADM_USER envvar is not set');
-        assert.ok(process.env.JOYENT_IMGADM_IDENTITY,
-            'JOYENT_IMGADM_IDENTITY envvar is not set');
-        options.user = process.env.JOYENT_IMGADM_USER;
+    if (process.env.IMGAPI_URL === 'https://images.smartos.org') {
+        assert.ok(process.env.IMAGES_IMGADM_USER,
+            'IMAGES_IMGADM_USER envvar is not set');
+        assert.ok(process.env.IMAGES_IMGADM_IDENTITY,
+            'IMAGES_IMGADM_IDENTITY envvar is not set');
+        options.user = process.env.IMAGES_IMGADM_USER;
         options.sign = imgapi.cliSigner({
-            keyId: process.env.JOYENT_IMGADM_IDENTITY,
-            user: process.env.JOYENT_IMGADM_USER
+            keyId: process.env.IMAGES_IMGADM_IDENTITY,
+            user: process.env.IMAGES_IMGADM_USER
         });
     }
     this.imgapiClient = imgapi.createClient(options);

--- a/test/runtests
+++ b/test/runtests
@@ -7,6 +7,7 @@
 
 #
 # Copyright 2016 Joyent, Inc.
+# Copyright 2022 MNX Cloud, Inc.
 #
 
 #
@@ -235,8 +236,8 @@ fi
 echo "# IMGAPI_URL is $IMGAPI_URL"
 
 
-# Guard against running 'public' tests against production images.joyent.com.
-if [[ "$IMGAPI_URL" == "https://images.joyent.com" ]]; then
+# Guard against running 'public' tests against production images.smartos.org.
+if [[ "$IMGAPI_URL" == "https://images.smartos.org" ]]; then
     echo "runtests: error: don't run the test suite against images.jo"
     exit 1
 fi
@@ -291,7 +292,7 @@ if [[ "$opt_mode" == "dc" ]]; then
 else
     # Public mode tests are a separate set because:
     # - we aren't currently loading test data
-    # - we must be non-destructive for images.joyent.com tests
+    # - we must be non-destructive for images.smartos.org tests
     test_files=$(ls -1 test/*.test.js test/*.public-test.js || true)
 fi
 if [[ -n "$opt_test_pattern" ]]; then

--- a/tools/standalone/README.md
+++ b/tools/standalone/README.md
@@ -1,2 +1,3 @@
-Tooling for running a standalone IMGAPI instance (e.g. images.joyent.com
-and updates.joyent.com are examples). See notes in "docs/operator-guide.md".
+Tooling for running a standalone IMGAPI instance (e.g. images.smartos.org
+and updates.tritondatacenter.com are examples). See notes in
+"docs/operator-guide.md".

--- a/tools/standalone/tritonlogupload.sh
+++ b/tools/standalone/tritonlogupload.sh
@@ -7,6 +7,7 @@
 
 #
 # Copyright 2017 Joyent, Inc.
+# Copyright 2022 MNX Cloud, Inc.
 #
 
 #
@@ -22,7 +23,7 @@
 # Currently this is hardcoded for standalone IMGAPI usage, getting
 # manta config info from $CONFIG. TODO: generalize this.
 #
-# Based on https://github.com/joyent/manta-scripts/blob/master/backup.sh
+# Based on https://github.com/TritonDataCenter/manta-scripts/blob/master/backup.sh
 #
 
 if [[ -n "$TRACE" ]]; then


### PR DESCRIPTION
Note: There are some references in "legacy" scripts in the tools dir that I didn't bother updating. Also, it doesn't look like there's any substantive changes to imgapi itself. The most significant difference is changes to the standalone deploy stuff.