### PR TITLE
TRITON-2345 Return accurate error when attempting to import an invalid img alias

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # IMGAPI changelog
 
+## 4.12.2
+
+- TRITON-2345 Return accurate error when attempting to import an invalid img alias
+
 ## 4.12.1
 
 - TRITON-2326 CVE-2020-7712 Command injection in json

--- a/lib/lxd.js
+++ b/lib/lxd.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2021 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
@@ -619,7 +620,7 @@ function parseLxdImageAlias(fullAlias) {
     if (idx === -1) {
         errs.push({ field: 'alias', code: 'InvalidParameter' });
         return new errors.InvalidParameterError(
-            'alias must include a semicolon', errs);
+            'alias must include a colon', errs);
     }
 
     var repo = fullAlias.substr(0, idx);
@@ -692,7 +693,8 @@ function adminImportLxdImage(opts, callback) {
 
     // Validate inputs.
     var parsedAlias = parseLxdImageAlias(alias);
-    if (parsedAlias instanceof errors.ValidationFailedError) {
+    if (parsedAlias instanceof errors.ValidationFailedError ||
+        parsedAlias instanceof errors.InvalidParameterError) {
         callback(parsedAlias);
         return;
     }

--- a/lib/lxd.js
+++ b/lib/lxd.js
@@ -617,10 +617,10 @@ function parseLxdImageAlias(fullAlias) {
     }
 
     var idx = fullAlias.indexOf(':');
-    if (idx === -1) {
+    if (idx < 1) {
         errs.push({ field: 'alias', code: 'InvalidParameter' });
         return new errors.InvalidParameterError(
-            'alias must include a colon', errs);
+            'alias must be in the format "registry:image"', errs);
     }
 
     var repo = fullAlias.substr(0, idx);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "imgapi",
   "description": "Image API to manage images for Triton Data Center",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "author": "MNX Cloud (mnxsolutions.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
The example lxd image alias [in the docs](https://docs.tritondatacenter.com/private-cloud/install/linux-compute-node-installation) is incorrectly formatted and returns the following error:

```json
{
  "type": "error",
  "id": "debian/11/cloud",
  "error": {
    "code": "InvalidParameter",
    "message": "No registry found for \"undefined\" - valid registries are \"images, ubuntu\""
  },
  "alias": "debian/11/cloud"
}
```

This PR propagates the actual error when a registry is absent, resulting in the following error message:

```json
{
  "code": "InvalidParameter",
  "message": "alias must be in the format \"registry:image\"",
  "errors": [
    {
      "field": "alias",
      "code": "InvalidParameter"
    }
  ]
}
```

Additional testing notes on [TRITON-2345](https://mnx.atlassian.net/browse/TRITON-2345)